### PR TITLE
Add support for terminal disconnection events

### DIFF
--- a/SimpleWebSocketServer.SIBS.Server/Enums/Enums.cs
+++ b/SimpleWebSocketServer.SIBS.Server/Enums/Enums.cs
@@ -48,7 +48,8 @@ namespace SimpleWebSocketServer.SIBS.Server.Enums
             LINQ_TERMINAL_TO_FRONT_REQUEST,
             LINQ_TERMINAL_TO_FRONT_RESPONSE,
             CLIENT_CONNECTED_RESPONSE,
-            NEW_TERMINAL_CONNECTED_REQUEST
+            NEW_TERMINAL_CONNECTED_REQUEST,
+            TERMINAL_DISCONNECTED
         }
 
         public enum AuthorizationType

--- a/SimpleWebSocketServer.SIBS.Server/Models/TerminalDisconnected.cs
+++ b/SimpleWebSocketServer.SIBS.Server/Models/TerminalDisconnected.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using static SimpleWebSocketServer.SIBS.Server.Enums.Enums;
+
+namespace SimpleWebSocketServer.SIBS.Server.Models
+{
+    public class TerminalDisconnected
+    {
+        [JsonProperty("version")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Version Version { get; set; } = Version.V_1;
+
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RequestType Type { get; set; } = RequestType.TERMINAL_DISCONNECTED;
+    }
+}

--- a/SimpleWebSocketServer.SIBS.Server/SimpleWebSocketServer.SIBS.Server.csproj
+++ b/SimpleWebSocketServer.SIBS.Server/SimpleWebSocketServer.SIBS.Server.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Models\ProcessPaymentReq.cs" />
     <Compile Include="Models\PairingReq.cs" />
     <Compile Include="Models\ListTerminalsReq.cs" />
+    <Compile Include="Models\TerminalDisconnected.cs" />
     <Compile Include="Models\TerminalStatusReq.cs" />
     <Compile Include="Models\NewTerminalConnectedReq.cs" />
     <Compile Include="Models\TransactionResponse.cs" />

--- a/SimpleWebSocketServer.SIBS.Server/WebSocketServerSibs.cs
+++ b/SimpleWebSocketServer.SIBS.Server/WebSocketServerSibs.cs
@@ -286,9 +286,17 @@ namespace SimpleWebSocketServer.SIBS.Server
                 _fronts.TryRemove(e.clientId, out _);
 
             // Unlink terminal from front
-            var terminal = _terminalToFrontMap.FirstOrDefault(kvp => kvp.Value == e.clientId);
+            var terminal = _terminalToFrontMap.FirstOrDefault(kvp => kvp.Key == e.clientId);
             if (!terminal.Equals(default(KeyValuePair<Guid, Guid>)))
+            {
                 _terminalToFrontMap.TryRemove(terminal.Key, out _);
+                SendMessageToClients(new List<(Guid clientId, string message)> { (terminal.Value, JsonConvert.SerializeObject(new TerminalDisconnected())) }).Wait();
+            }
+
+            // Unlink front from terminal
+            var front = _terminalToFrontMap.FirstOrDefault(kvp => kvp.Value == e.clientId);
+            if (!front.Equals(default(KeyValuePair<Guid, Guid>)))
+                _terminalToFrontMap.TryRemove(front.Key, out _);
 
             ClientDisconnected?.Invoke(this, new EventArgs());
         }


### PR DESCRIPTION
Introduced a new `TerminalDisconnected` model and updated the `RequestType` enum to include `TERMINAL_DISCONNECTED`. Enhanced WebSocket server logic to handle terminal disconnection events, including sending disconnection messages to clients and properly unlinking terminals and fronts. Updated the project file to include the new model.